### PR TITLE
Fixed min/maxOccurs for group references.

### DIFF
--- a/XSDDiagrams/Rendering/Diagram.cs
+++ b/XSDDiagrams/Rendering/Diagram.cs
@@ -327,6 +327,8 @@ namespace XSDDiagram.Rendering
 			{
 				DiagramItem childDiagramGroup = new DiagramItem();
 				childDiagramGroup.ItemType = DiagramItemType.group;
+
+				XMLSchema.group referenceGroup = null;
 				if (childGroup.@ref != null)
 				{
 					childDiagramGroup.IsReference = true;
@@ -337,7 +339,10 @@ namespace XSDDiagram.Rendering
                     {
                         XMLSchema.group group = grpObject.Tag as XMLSchema.group;
                         if (group != null)
+                        {
+                            referenceGroup = childGroup;
                             childGroup = group;
+                        }
                     }
 				}
 				else if (type == DiagramItemGroupType.Group)
@@ -353,13 +358,13 @@ namespace XSDDiagram.Rendering
 				childDiagramGroup.Diagram = this;
 				childDiagramGroup.TabSchema = childGroup;
 				int occurrence;
-				if (int.TryParse(childGroup.minOccurs, out occurrence))
+				if (int.TryParse(referenceGroup != null ? referenceGroup.minOccurs : childGroup.minOccurs, out occurrence))
 					childDiagramGroup.MinOccurrence = occurrence;
 				else
 					childDiagramGroup.MinOccurrence = -1;
 				//try { childDiagramGroup.MinOccurrence = int.Parse(childGroup.minOccurs); }
 				//catch { childDiagramGroup.MinOccurrence = -1; }
-				if (int.TryParse(childGroup.maxOccurs, out occurrence))
+				if (int.TryParse(referenceGroup != null ? referenceGroup.maxOccurs : childGroup.maxOccurs, out occurrence))
 					childDiagramGroup.MaxOccurrence = occurrence;
 				else
 					childDiagramGroup.MaxOccurrence = -1;


### PR DESCRIPTION
Let's consider the schema:
```xml
<?xml version="1.0"?>
<xs:schema version="1.0"
		   xmlns:xs="http://www.w3.org/2001/XMLSchema"
		   elementFormDefault="qualified">

	<xs:group name="grp" >
		<xs:sequence>
			<xs:element name="el" />
		</xs:sequence>
	</xs:group>
	
	<xs:element name="root">
		<xs:complexType>
			<xs:group ref="grp" minOccurs="7" maxOccurs="12" />
		</xs:complexType>
	</xs:element>
</xs:schema>
```

Currently if we add the `root` element to the diagram and expand it, the `grp` element is rendered as having `minOccurs=1` and `maxOccurs=1` - these are the default values and they are taken from the _definition_ of the group. But this is incorrect because the values should be taken from the tag with the `ref` attribute. Furthermore it is illegal to have these attributes at the group definition.

Corrections are made in `Diagram.AddCompositors()` in the same way that the problem is already avoided in `Diagram.AddElement()`